### PR TITLE
feat: Custom Field, difficulties, themes, menus, and draggable windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # Minesweeper
 
+A faithful remake of the classic Windows Minesweeper, built with React, TypeScript, and
+Vite. Play it at **[minesweeper.is](https://minesweeper.is/)**.
+
+Choose Beginner, Intermediate, Expert, or a custom board, flag suspected mines, and clear
+the field without detonating one.
+
 ## Monorepo layout
 
 This repository is a pnpm + Turborepo monorepo:
@@ -10,91 +16,30 @@ This repository is a pnpm + Turborepo monorepo:
 - `workers/api` — AWS Lambda API (`@minesweeper/api`), currently a skeleton
 - `packages/` — reserved for shared code
 
-Run `pnpm <script>` from the repo root (delegates through Turborepo), or
-target one package with `pnpm --filter @minesweeper/web <script>`.
+Run `pnpm <script>` from the repo root (delegates through Turborepo), or target one package
+with `pnpm --filter @minesweeper/web <script>`.
 
-# React + TypeScript + Vite
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default {
-  // other rules...
-  parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
-    tsconfigRootDir: __dirname,
-  },
-}
-```
-
-- Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
-- Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
-
-## Getting Started
-
-To get started with this project, simply run:
+## Getting started
 
 ```bash
 pnpm install
 pnpm dev
 ```
 
-## Available Scripts
+## Scripts
 
-In the project directory, you can run:
+Run from the repo root:
 
-### `yarn start`yarn start`
+- `pnpm dev` — start the Vite dev server
+- `pnpm build` — type-check and build for production (output in `apps/web/build`)
+- `pnpm lint` — ESLint (`--max-warnings 0`)
+- `pnpm test` — run the Vitest suite
+- `pnpm test:coverage` — tests with coverage
 
-Runs the app in the development mode.\
+## Tech stack
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+React 19 · TypeScript · Vite · TanStack Query · Zustand · MSW · Vitest.
 
-### `yarn test`
+## License
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `yarn build`
-
-Builds the app for production to the `dist` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-### `yarn preview`
-
-Your app is ready to be deployed! just previewing our app without publishing it, yet. We can use this command at anytime to preview our app.
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### Learn More
-
-To learn more about Vite, check out the [official documentation](https://vitejs.dev/guide/).
-
-To learn more about React, check out the [official documentation](https://reactjs.org/docs/getting-started.html).
-
-In this example, we've added an introduction to Vite, a brief overview of the app, and instructions for getting started, building for production, and running tests. We've also provided links to the official documentation for both Vite and React.
-
-# Vite ⚡
-
-> Next Generation Frontend Tooling
-
-- 💡 Instant Server Start
-- ⚡️ Lightning Fast HMR
-- 🛠️ Rich Features
-- 📦 Optimized Build
-- 🔩 Universal Plugin Interface
-- 🔑 Fully Typed APIs
+[Prosperity Public License 3.0](https://licensezero.com/licenses/prosperity-3.0).

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,9 +12,36 @@
       gtag('config', 'G-FGZKK2H1Q4')
     </script>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/minesweeper.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link rel="icon" type="image/png" href="/minesweeper.png" />
+    <link rel="canonical" href="https://minesweeper.is/" />
+
+    <title>Minesweeper — Play the Classic Game Online</title>
+    <meta
+      name="description"
+      content="Play Minesweeper online — the classic Windows puzzle game with a retro look. Clear the board on Beginner, Intermediate, Expert, or a custom size."
+    />
+    <meta name="theme-color" content="#008080" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Minesweeper" />
+    <meta property="og:title" content="Minesweeper — Play the Classic Game Online" />
+    <meta
+      property="og:description"
+      content="Play Minesweeper online — the classic Windows puzzle game with a retro look. Clear the board on Beginner, Intermediate, Expert, or a custom size."
+    />
+    <meta property="og:url" content="https://minesweeper.is/" />
+    <meta property="og:image" content="https://minesweeper.is/minesweeper.png" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Minesweeper — Play the Classic Game Online" />
+    <meta
+      name="twitter:description"
+      content="Play Minesweeper online — the classic Windows puzzle game with a retro look. Clear the board on Beginner, Intermediate, Expert, or a custom size."
+    />
+    <meta name="twitter:image" content="https://minesweeper.is/minesweeper.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.css
+++ b/apps/web/src/App.css
@@ -2,7 +2,6 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
 }
 
 *,

--- a/apps/web/src/assets/face-surprised.svg
+++ b/apps/web/src/assets/face-surprised.svg
@@ -1,0 +1,54 @@
+<svg viewBox="1 1 14 14" shape-rendering="crispEdges" xmlns="http://www.w3.org/2000/svg">
+  <g fill="#ff0">
+    <rect x="6" y="2" width="4" height="1"/>
+    <rect x="4" y="3" width="8" height="1"/>
+    <rect x="3" y="4" width="10" height="1"/>
+    <rect x="3" y="5" width="10" height="1"/>
+    <rect x="2" y="6" width="12" height="1"/>
+    <rect x="2" y="7" width="12" height="1"/>
+    <rect x="2" y="8" width="12" height="1"/>
+    <rect x="2" y="9" width="12" height="1"/>
+    <rect x="3" y="10" width="10" height="1"/>
+    <rect x="3" y="11" width="10" height="1"/>
+    <rect x="4" y="12" width="8" height="1"/>
+    <rect x="6" y="13" width="4" height="1"/>
+  </g>
+  <g fill="#000">
+    <rect x="6" y="1" width="4" height="1"/>
+    <rect x="4" y="2" width="2" height="1"/>
+    <rect x="10" y="2" width="2" height="1"/>
+    <rect x="3" y="3" width="1" height="1"/>
+    <rect x="12" y="3" width="1" height="1"/>
+    <rect x="2" y="4" width="1" height="1"/>
+    <rect x="13" y="4" width="1" height="1"/>
+    <rect x="2" y="5" width="1" height="1"/>
+    <rect x="13" y="5" width="1" height="1"/>
+    <rect x="1" y="6" width="1" height="1"/>
+    <rect x="14" y="6" width="1" height="1"/>
+    <rect x="1" y="7" width="1" height="1"/>
+    <rect x="14" y="7" width="1" height="1"/>
+    <rect x="1" y="8" width="1" height="1"/>
+    <rect x="14" y="8" width="1" height="1"/>
+    <rect x="1" y="9" width="1" height="1"/>
+    <rect x="14" y="9" width="1" height="1"/>
+    <rect x="2" y="10" width="1" height="1"/>
+    <rect x="13" y="10" width="1" height="1"/>
+    <rect x="2" y="11" width="1" height="1"/>
+    <rect x="13" y="11" width="1" height="1"/>
+    <rect x="3" y="12" width="1" height="1"/>
+    <rect x="12" y="12" width="1" height="1"/>
+    <rect x="4" y="13" width="2" height="1"/>
+    <rect x="10" y="13" width="2" height="1"/>
+    <rect x="6" y="14" width="4" height="1"/>
+    <rect x="5" y="5" width="2" height="1"/>
+    <rect x="9" y="5" width="2" height="1"/>
+    <rect x="5" y="6" width="2" height="1"/>
+    <rect x="9" y="6" width="2" height="1"/>
+    <rect x="7" y="8" width="2" height="1"/>
+    <rect x="6" y="9" width="1" height="1"/>
+    <rect x="9" y="9" width="1" height="1"/>
+    <rect x="6" y="10" width="1" height="1"/>
+    <rect x="9" y="10" width="1" height="1"/>
+    <rect x="7" y="11" width="2" height="1"/>
+  </g>
+</svg>

--- a/apps/web/src/assets/window-close.svg
+++ b/apps/web/src/assets/window-close.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 3 L9 9 M9 3 L3 9" stroke="#000" stroke-width="1.7" stroke-linecap="square" />
+</svg>

--- a/apps/web/src/assets/window-maximize.svg
+++ b/apps/web/src/assets/window-maximize.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2.5" y="2.5" width="7" height="7" fill="none" stroke="#000" stroke-width="1" />
+  <rect x="2.5" y="2.5" width="7" height="2" fill="#000" />
+</svg>

--- a/apps/web/src/assets/window-minimize.svg
+++ b/apps/web/src/assets/window-minimize.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2.5" y="8" width="5" height="1.8" fill="#000" />
+</svg>

--- a/apps/web/src/common/components/Window.test.tsx
+++ b/apps/web/src/common/components/Window.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Window } from './Window'
+
+describe('Window', () => {
+  it('renders the title and children', () => {
+    render(
+      <Window title="Minesweeper">
+        <p>content</p>
+      </Window>,
+    )
+    expect(screen.getByText('Minesweeper')).toBeInTheDocument()
+    expect(screen.getByText('content')).toBeInTheDocument()
+  })
+
+  it('renders the icon when provided', () => {
+    render(
+      <Window title="Minesweeper" icon="/icon.svg">
+        <p>content</p>
+      </Window>,
+    )
+    expect(document.querySelector('.titleBar .icon')).toHaveAttribute('src', '/icon.svg')
+  })
+
+  it('shows the three decorative buttons for the app variant', () => {
+    render(<Window title="Minesweeper">app</Window>)
+    const buttons = document.querySelectorAll('.windowButton')
+    expect(Array.from(buttons).map((b) => b.textContent)).toEqual(['—', '🗖', '✕'])
+  })
+
+  it('shows a single close button wired to onClose for the dialog variant', () => {
+    const onClose = vi.fn()
+    render(
+      <Window title="Custom Field" variant="dialog" onClose={onClose}>
+        dialog
+      </Window>,
+    )
+    const buttons = document.querySelectorAll('.windowButton')
+    expect(buttons).toHaveLength(1)
+    fireEvent.click(buttons[0])
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/common/components/Window.test.tsx
+++ b/apps/web/src/common/components/Window.test.tsx
@@ -21,10 +21,12 @@ describe('Window', () => {
     expect(document.querySelector('.titleBar .icon')).toHaveAttribute('src', '/icon.svg')
   })
 
-  it('shows the three decorative buttons for the app variant', () => {
+  it('shows the minimize, maximize and close buttons for the app variant', () => {
     render(<Window title="Minesweeper">app</Window>)
-    const buttons = document.querySelectorAll('.windowButton')
-    expect(Array.from(buttons).map((b) => b.textContent)).toEqual(['—', '🗖', '✕'])
+    const alts = Array.from(document.querySelectorAll('.windowButton img')).map((img) =>
+      img.getAttribute('alt'),
+    )
+    expect(alts).toEqual(['minimize', 'maximize', 'close'])
   })
 
   it('shows a single close button wired to onClose for the dialog variant', () => {

--- a/apps/web/src/common/components/Window.test.tsx
+++ b/apps/web/src/common/components/Window.test.tsx
@@ -41,4 +41,28 @@ describe('Window', () => {
     fireEvent.click(buttons[0])
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('moves the window when dragging the title bar', () => {
+    const { container } = render(<Window title="Minesweeper">content</Window>)
+    const win = container.querySelector('.window') as HTMLElement
+    const titleBar = container.querySelector('.titleBar') as HTMLElement
+    expect(win.style.transform).toBe('translate(0px, 0px)')
+
+    fireEvent.mouseDown(titleBar, { clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { clientX: 60, clientY: 40 })
+    fireEvent.mouseUp(document)
+
+    expect(win.style.transform).toBe('translate(50px, 30px)')
+  })
+
+  it('does not start a drag when pressing a title-bar button', () => {
+    const { container } = render(<Window title="Minesweeper">content</Window>)
+    const win = container.querySelector('.window') as HTMLElement
+    const button = container.querySelector('.windowButton') as HTMLElement
+
+    fireEvent.mouseDown(button, { clientX: 10, clientY: 10 })
+    fireEvent.mouseMove(document, { clientX: 60, clientY: 40 })
+
+    expect(win.style.transform).toBe('translate(0px, 0px)')
+  })
 })

--- a/apps/web/src/common/components/Window.tsx
+++ b/apps/web/src/common/components/Window.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react'
+import './window.css'
+
+type WindowProps = {
+  title: string
+  icon?: string
+  // 'app' shows the classic minimize/maximize/close buttons (decorative).
+  // 'dialog' shows a single close button wired to `onClose`.
+  variant?: 'app' | 'dialog'
+  onClose?: () => void
+  children: ReactNode
+}
+
+// Reusable classic Windows window chrome: the raised frame plus a title bar
+// with an optional icon, the title, and the top-right buttons.
+export const Window = ({ title, icon, variant = 'app', onClose, children }: WindowProps) => {
+  return (
+    <div className={`window${variant === 'dialog' ? ' dialog' : ''}`}>
+      <div className="titleBar">
+        {icon && <img className="icon" src={icon} alt="" />}
+        <span className="title">{title}</span>
+        <span className="windowButtons">
+          {variant === 'app' ? (
+            <>
+              <span className="windowButton">—</span>
+              <span className="windowButton">🗖</span>
+              <span className="windowButton">✕</span>
+            </>
+          ) : (
+            <span className="windowButton" onClick={onClose}>
+              ✕
+            </span>
+          )}
+        </span>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/apps/web/src/common/components/Window.tsx
+++ b/apps/web/src/common/components/Window.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { type MouseEvent as ReactMouseEvent, type ReactNode, useRef, useState } from 'react'
 import './window.css'
 import minimizeIcon from '../../assets/window-minimize.svg'
 import maximizeIcon from '../../assets/window-maximize.svg'
@@ -14,12 +14,51 @@ type WindowProps = {
   children: ReactNode
 }
 
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
 // Reusable classic Windows window chrome: the raised frame plus a title bar
-// with an optional icon, the title, and the top-right buttons.
+// with an optional icon, the title, and the top-right buttons. Drag the title
+// bar to move the window; it stays within the viewport.
 export const Window = ({ title, icon, variant = 'app', onClose, children }: WindowProps) => {
+  const windowRef = useRef<HTMLDivElement>(null)
+  const [offset, setOffset] = useState({ x: 0, y: 0 })
+
+  const handleTitleBarMouseDown = (event: ReactMouseEvent<HTMLDivElement>) => {
+    // Let the top-right buttons handle their own clicks without starting a drag.
+    if ((event.target as HTMLElement).closest('.windowButtons')) return
+    const element = windowRef.current
+    if (!element) return
+
+    const rect = element.getBoundingClientRect()
+    // Position of the window with the current transform removed.
+    const base = { left: rect.left - offset.x, top: rect.top - offset.y }
+    const startX = event.clientX
+    const startY = event.clientY
+    const startOffset = { ...offset }
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const maxX = window.innerWidth - rect.width
+      const maxY = window.innerHeight - rect.height
+      setOffset({
+        x: clamp(startOffset.x + (moveEvent.clientX - startX), -base.left, maxX - base.left),
+        y: clamp(startOffset.y + (moveEvent.clientY - startY), -base.top, maxY - base.top),
+      })
+    }
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+    }
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  }
+
   return (
-    <div className={`window${variant === 'dialog' ? ' dialog' : ''}`}>
-      <div className="titleBar">
+    <div
+      ref={windowRef}
+      className={`window${variant === 'dialog' ? ' dialog' : ''}`}
+      style={{ transform: `translate(${offset.x}px, ${offset.y}px)` }}
+    >
+      <div className="titleBar" onMouseDown={handleTitleBarMouseDown}>
         {icon && <img className="icon" src={icon} alt="" />}
         <span className="title">{title}</span>
         <span className="windowButtons">

--- a/apps/web/src/common/components/Window.tsx
+++ b/apps/web/src/common/components/Window.tsx
@@ -1,5 +1,8 @@
 import { type ReactNode } from 'react'
 import './window.css'
+import minimizeIcon from '../../assets/window-minimize.svg'
+import maximizeIcon from '../../assets/window-maximize.svg'
+import closeIcon from '../../assets/window-close.svg'
 
 type WindowProps = {
   title: string
@@ -22,13 +25,19 @@ export const Window = ({ title, icon, variant = 'app', onClose, children }: Wind
         <span className="windowButtons">
           {variant === 'app' ? (
             <>
-              <span className="windowButton">—</span>
-              <span className="windowButton">🗖</span>
-              <span className="windowButton">✕</span>
+              <span className="windowButton">
+                <img src={minimizeIcon} alt="minimize" />
+              </span>
+              <span className="windowButton disabled">
+                <img src={maximizeIcon} alt="maximize" />
+              </span>
+              <span className="windowButton">
+                <img src={closeIcon} alt="close" />
+              </span>
             </>
           ) : (
             <span className="windowButton" onClick={onClose}>
-              ✕
+              <img src={closeIcon} alt="close" />
             </span>
           )}
         </span>

--- a/apps/web/src/common/components/window.css
+++ b/apps/web/src/common/components/window.css
@@ -2,8 +2,15 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  border: 4px outset #fff;
+  padding: 4px;
   background-color: #ddd;
+  /* Classic Windows raised window frame, sampled from the reference: a light
+     highlight on the top/left and a dark shadow on the bottom/right. */
+  box-shadow:
+    inset 1px 1px #d0ccc0,
+    inset 2px 2px #f8fcf8,
+    inset -1px -1px #383c38,
+    inset -2px -2px #787c78;
 }
 
 .window .titleBar {
@@ -17,7 +24,6 @@
   font-family: 'W95FA', 'pixel-art', sans-serif;
   font-size: 16px;
   -webkit-font-smoothing: none;
-  margin: 2px;
 }
 
 .window .titleBar .icon {
@@ -37,8 +43,34 @@
 }
 
 .window .windowButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 18px;
   height: 18px;
+  border: 2px outset #fff;
+  background-color: #ddd;
+  cursor: default;
+}
+
+.window .windowButton img {
+  display: block;
+  width: 11px;
+  height: 11px;
+}
+
+.window .windowButton:active {
+  border-style: inset;
+}
+
+/* Disabled button (e.g. maximize on the fixed-size board window): grayed icon,
+   and it doesn't press in. invert(0.5) turns the black glyph into #808080. */
+.window .windowButton.disabled img {
+  filter: invert(0.5);
+}
+
+.window .windowButton.disabled:active {
+  border-style: outset;
 }
 
 .window.dialog {

--- a/apps/web/src/common/components/window.css
+++ b/apps/web/src/common/components/window.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   padding: 4px;
-  background-color: #ddd;
+  background-color: var(--body, #ddd);
   /* Classic Windows raised window frame, sampled from the reference: a light
      highlight on the top/left and a dark shadow on the bottom/right. */
   box-shadow:
@@ -19,8 +19,13 @@
   align-self: stretch;
   gap: 6px;
   padding: 3px 4px;
-  background: linear-gradient(90deg, #0a246a, #3a6ea5, #6a8ccb);
-  color: #fff;
+  background: linear-gradient(
+    90deg,
+    var(--title-a, #0a246a),
+    var(--title-b, #3a6ea5),
+    var(--title-c, #6a8ccb)
+  );
+  color: var(--title-text, #fff);
   font-family: 'W95FA', 'pixel-art', sans-serif;
   font-size: 16px;
   -webkit-font-smoothing: none;
@@ -48,8 +53,8 @@
   justify-content: center;
   width: 18px;
   height: 18px;
-  border: 2px outset #fff;
-  background-color: #ddd;
+  border: 2px outset var(--bevel, #fff);
+  background-color: var(--body, #ddd);
   cursor: default;
 }
 

--- a/apps/web/src/common/components/window.css
+++ b/apps/web/src/common/components/window.css
@@ -1,0 +1,46 @@
+.window {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 4px outset #fff;
+  background-color: #ddd;
+}
+
+.window .titleBar {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  gap: 6px;
+  padding: 3px 4px;
+  background: linear-gradient(90deg, #0a246a, #3a6ea5, #6a8ccb);
+  color: #fff;
+  font-family: 'W95FA', 'pixel-art', sans-serif;
+  font-size: 16px;
+  -webkit-font-smoothing: none;
+  margin: 2px;
+}
+
+.window .titleBar .icon {
+  width: 16px;
+  height: 16px;
+  margin: 0 4px;
+}
+
+.window .titleBar .title {
+  flex: 1;
+  text-align: left;
+}
+
+.window .windowButtons {
+  display: flex;
+  gap: 2px;
+}
+
+.window .windowButton {
+  width: 18px;
+  height: 18px;
+}
+
+.window.dialog {
+  align-items: stretch;
+}

--- a/apps/web/src/common/components/window.css
+++ b/apps/web/src/common/components/window.css
@@ -17,6 +17,7 @@
   display: flex;
   align-items: center;
   align-self: stretch;
+  cursor: move;
   gap: 6px;
   padding: 3px 4px;
   background: linear-gradient(

--- a/apps/web/src/common/consts.ts
+++ b/apps/web/src/common/consts.ts
@@ -1,6 +1,8 @@
-const on_ = '#c00' // active color
-const off = '#600000' // inActive color
-const def = '#1E262E' // default color
+// LED segment colors resolve from the active theme's CSS variables (see
+// minesweeper.css), with the classic values as fallbacks.
+const on_ = 'var(--led-on, #c00)' // active color
+const off = 'var(--led-off, #600000)' // inactive color
+const def = 'var(--led-def, #1e262e)' // default color
 export type DigitKeys =
   '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'default' | 'key'
 export const segmentMap: Record<DigitKeys, string[]> = {

--- a/apps/web/src/common/hooks/useBoardMutation.ts
+++ b/apps/web/src/common/hooks/useBoardMutation.ts
@@ -1,27 +1,26 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import client from '../../utils/api/client'
-import { useBoard } from './useBoard'
 import { type Board } from '../../utils/generateMinesweeperGrid'
 import { type Update } from '../../utils/mineField'
 
-export const useBoardMutation = () => {
-  const { result } = useBoard()
-  const id = result?.data?.id || 'new'
+// `boardId` is the id of the board being played. Taking it as an argument (the
+// caller already knows it) avoids a second useBoard() observer that would race
+// the board query with default options and pin every new game to 9×9.
+export const useBoardMutation = (boardId: string = 'new') => {
   const config = {
-    url: `/board/${id}`,
+    url: `/board/${boardId}`,
     method: 'post',
   }
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (data: Update) => client.call<Board, Board>({ data, ...config }),
     onSuccess: (data) => {
-      queryClient.setQueryData<Board>(['board', id], (oldData) => {
+      queryClient.setQueryData<Board>(['board', boardId], (oldData) => {
         return {
           ...oldData,
           ...data,
         }
       })
-      // queryClient.invalidateQueries(['board', board?.id])
     },
   })
 }

--- a/apps/web/src/common/store/useFlagStore.test.ts
+++ b/apps/web/src/common/store/useFlagStore.test.ts
@@ -3,7 +3,7 @@ import { flagCount, useFlagStore } from './useFlagStore.ts'
 const { getState, setState } = useFlagStore
 const BOARD = 'board-1'
 
-beforeEach(() => setState({ mines: 10, boards: {} }))
+beforeEach(() => setState({ mines: 10, boards: {}, marks: true }))
 
 describe('useFlagStore', () => {
   it('cycles a cell none -> flag -> question -> none', () => {
@@ -33,6 +33,31 @@ describe('useFlagStore', () => {
     expect(getState().boards[BOARD]['0:0']).toBe('flag')
     expect(getState().boards[BOARD]['1:0']).toBe('question')
     expect(flagCount(getState().boards[BOARD])).toBe(1)
+  })
+
+  it('cycles a cell flag -> none when marks are off, skipping the question', () => {
+    setState({ marks: false })
+    getState().cycleFlag(BOARD, '0:0')
+    expect(getState().boards[BOARD]['0:0']).toBe('flag')
+
+    getState().cycleFlag(BOARD, '0:0')
+    expect(getState().boards[BOARD]['0:0']).toBeUndefined()
+  })
+
+  it('leaves a capped cell unmarked when marks are off', () => {
+    setState({ mines: 1, boards: {}, marks: false })
+    getState().cycleFlag(BOARD, '0:0') // flag — reaches the cap
+    getState().cycleFlag(BOARD, '1:0') // cap reached, marks off -> stays none
+
+    expect(getState().boards[BOARD]['1:0']).toBeUndefined()
+  })
+
+  it('toggleMarks flips the marks setting', () => {
+    expect(getState().marks).toBe(true)
+    getState().toggleMarks()
+    expect(getState().marks).toBe(false)
+    getState().toggleMarks()
+    expect(getState().marks).toBe(true)
   })
 
   it('keeps marks isolated per board', () => {

--- a/apps/web/src/common/store/useFlagStore.test.ts
+++ b/apps/web/src/common/store/useFlagStore.test.ts
@@ -3,7 +3,7 @@ import { flagCount, useFlagStore } from './useFlagStore.ts'
 const { getState, setState } = useFlagStore
 const BOARD = 'board-1'
 
-beforeEach(() => setState({ mines: 10, boards: {}, marks: true }))
+beforeEach(() => setState({ mines: 10, boards: {}, marks: true, color: true }))
 
 describe('useFlagStore', () => {
   it('cycles a cell none -> flag -> question -> none', () => {
@@ -58,6 +58,14 @@ describe('useFlagStore', () => {
     expect(getState().marks).toBe(false)
     getState().toggleMarks()
     expect(getState().marks).toBe(true)
+  })
+
+  it('toggleColor flips the color setting', () => {
+    expect(getState().color).toBe(true)
+    getState().toggleColor()
+    expect(getState().color).toBe(false)
+    getState().toggleColor()
+    expect(getState().color).toBe(true)
   })
 
   it('keeps marks isolated per board', () => {

--- a/apps/web/src/common/store/useFlagStore.ts
+++ b/apps/web/src/common/store/useFlagStore.ts
@@ -10,10 +10,13 @@ interface FlagStore {
   // When on, the mark cycle includes the ❓ question mark; when off it is just
   // flag ⇄ none. Toggled by the "Marks (?)" menu entry.
   marks: boolean
+  // When off, the window renders in grayscale. Toggled by the "Color" entry.
+  color: boolean
   // Marks are namespaced by board id, so each game has its own isolated set.
   boards: Record<string, BoardFlags>
   setMines: (mines: number) => void
   toggleMarks: () => void
+  toggleColor: () => void
   cycleFlag: (boardId: string, key: string) => void
 }
 
@@ -24,9 +27,11 @@ export const flagCount = (flags: BoardFlags = {}): number =>
 export const useFlagStore = create<FlagStore>((set) => ({
   mines: 0,
   marks: true,
+  color: true,
   boards: {},
   setMines: (mines) => set({ mines }),
   toggleMarks: () => set((state) => ({ marks: !state.marks })),
+  toggleColor: () => set((state) => ({ color: !state.color })),
   cycleFlag: (boardId, key) =>
     set((state) => {
       const boardFlags = { ...state.boards[boardId] }

--- a/apps/web/src/common/store/useFlagStore.ts
+++ b/apps/web/src/common/store/useFlagStore.ts
@@ -7,9 +7,13 @@ export type BoardFlags = Record<string, FlagState>
 
 interface FlagStore {
   mines: number
+  // When on, the mark cycle includes the ❓ question mark; when off it is just
+  // flag ⇄ none. Toggled by the "Marks (?)" menu entry.
+  marks: boolean
   // Marks are namespaced by board id, so each game has its own isolated set.
   boards: Record<string, BoardFlags>
   setMines: (mines: number) => void
+  toggleMarks: () => void
   cycleFlag: (boardId: string, key: string) => void
 }
 
@@ -19,23 +23,28 @@ export const flagCount = (flags: BoardFlags = {}): number =>
 
 export const useFlagStore = create<FlagStore>((set) => ({
   mines: 0,
+  marks: true,
   boards: {},
   setMines: (mines) => set({ mines }),
+  toggleMarks: () => set((state) => ({ marks: !state.marks })),
   cycleFlag: (boardId, key) =>
     set((state) => {
       const boardFlags = { ...state.boards[boardId] }
       const current = boardFlags[key]
       if (current === 'flag') {
-        boardFlags[key] = 'question'
+        // With marks on, flag -> question; otherwise flag -> none.
+        if (state.marks) boardFlags[key] = 'question'
+        else delete boardFlags[key]
       } else if (current === 'question') {
         delete boardFlags[key]
       } else if (flagCount(state.boards[boardId]) < state.mines) {
         // none -> flag, but only while under the mine count
         boardFlags[key] = 'flag'
-      } else {
+      } else if (state.marks) {
         // mine count reached: can't add a flag, mark it as a question instead
         boardFlags[key] = 'question'
       }
+      // marks off and at the mine cap: stays none
       return { boards: { ...state.boards, [boardId]: boardFlags } }
     }),
 }))

--- a/apps/web/src/components/board/AboutWindow.test.tsx
+++ b/apps/web/src/components/board/AboutWindow.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AboutWindow } from './AboutWindow'
+
+describe('AboutWindow', () => {
+  it('renders the about content', () => {
+    render(<AboutWindow onClose={vi.fn()} />)
+    expect(screen.getByText('About Minesweeper')).toBeInTheDocument()
+    expect(screen.getByText(/faithful remake/i)).toBeInTheDocument()
+  })
+
+  it('closes from OK and the title-bar close button', () => {
+    const onClose = vi.fn()
+    render(<AboutWindow onClose={onClose} />)
+
+    fireEvent.click(screen.getByText('OK'))
+    fireEvent.click(screen.getByAltText('close'))
+
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/components/board/AboutWindow.tsx
+++ b/apps/web/src/components/board/AboutWindow.tsx
@@ -1,0 +1,23 @@
+import { Window } from '../../common/components/Window'
+
+type AboutWindowProps = {
+  onClose: () => void
+}
+
+// The "About Minesweeper" dialog, opened from the Help menu.
+export const AboutWindow = ({ onClose }: AboutWindowProps) => {
+  return (
+    <Window title="About Minesweeper" variant="dialog" onClose={onClose}>
+      <div className="helpBody">
+        <p>Minesweeper</p>
+        <p>A faithful remake of the classic Windows game.</p>
+        <p>Built with React &amp; TypeScript — play at minesweeper.is</p>
+        <div className="helpButtons">
+          <button className="windowButton dialogButton" onClick={onClose}>
+            OK
+          </button>
+        </div>
+      </div>
+    </Window>
+  )
+}

--- a/apps/web/src/components/board/Board.test.tsx
+++ b/apps/web/src/components/board/Board.test.tsx
@@ -81,6 +81,54 @@ describe('Board', () => {
     expect(win.classList.contains('grayscale')).toBe(true)
   })
 
+  it('opens the Help Topics window from the Help menu', () => {
+    render(renderWithProvider(MineSweeper))
+    expect(screen.queryByText(/Left-click a cell/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Help'))
+    fireEvent.click(screen.getByText('Help Topics'))
+    expect(screen.getByText(/Left-click a cell/)).toBeInTheDocument()
+  })
+
+  it('opens the About window from the Help menu', () => {
+    render(renderWithProvider(MineSweeper))
+    fireEvent.click(screen.getByText('Help'))
+    fireEvent.click(screen.getByText('About Minesweeper'))
+    expect(screen.getByText(/faithful remake/i)).toBeInTheDocument()
+  })
+
+  it('starts a fresh game from the Game > New menu', async () => {
+    let newRequests = 0
+    server.use(
+      http.get('/board/new', () => {
+        newRequests += 1
+        return HttpResponse.json(makeBoard(`new-${newRequests}`))
+      }),
+    )
+    render(renderWithProvider(MineSweeper))
+    const before = newRequests
+
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('New'))
+
+    await waitFor(() => expect(newRequests).toBeGreaterThan(before))
+  })
+
+  it('starts a fresh game with the F2 key', async () => {
+    let newRequests = 0
+    server.use(
+      http.get('/board/new', () => {
+        newRequests += 1
+        return HttpResponse.json(makeBoard(`f2-${newRequests}`))
+      }),
+    )
+    render(renderWithProvider(MineSweeper))
+    const before = newRequests
+
+    fireEvent.keyDown(document, { key: 'F2' })
+
+    await waitFor(() => expect(newRequests).toBeGreaterThan(before))
+  })
+
   // These select a difficulty, which evicts the shared 'board/new' cache — keep
   // them last so they don't disturb the board-content tests above.
   const menuCheckFor = (label: string) =>

--- a/apps/web/src/components/board/Board.test.tsx
+++ b/apps/web/src/components/board/Board.test.tsx
@@ -54,4 +54,37 @@ describe('Board', () => {
 
     await waitFor(() => expect(screen.getByAltText('smiling face')).toBeInTheDocument())
   })
+
+  // These select a difficulty, which evicts the shared 'board/new' cache — keep
+  // them last so they don't disturb the board-content tests above.
+  const menuCheckFor = (label: string) =>
+    screen
+      .getAllByRole('menuitem')
+      .find((item) => item.querySelector('.menuLabel')?.textContent === label)
+      ?.querySelector('.menuCheck')?.textContent
+
+  it('marks the chosen difficulty in the Game menu', () => {
+    render(renderWithProvider(MineSweeper))
+    fireEvent.click(screen.getByText('Game'))
+    expect(menuCheckFor('Beginner')).toBe('✓')
+
+    fireEvent.click(screen.getByText('Expert'))
+    fireEvent.click(screen.getByText('Game'))
+    expect(menuCheckFor('Expert')).toBe('✓')
+    expect(menuCheckFor('Beginner')).toBe('')
+  })
+
+  it('applies custom dimensions and marks Custom in the menu', () => {
+    render(renderWithProvider(MineSweeper))
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('Custom...'))
+
+    const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
+    fireEvent.change(inputs[0], { target: { value: '12' } })
+    fireEvent.click(screen.getByText('OK'))
+
+    expect(screen.queryByText('Custom Field')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Game'))
+    expect(menuCheckFor('Custom...')).toBe('✓')
+  })
 })

--- a/apps/web/src/components/board/Board.test.tsx
+++ b/apps/web/src/components/board/Board.test.tsx
@@ -36,6 +36,16 @@ describe('Board', () => {
     expect(screen.getByText('Help')).toBeInTheDocument()
   })
 
+  it('opens the Custom Field dialog from the Game menu', () => {
+    render(renderWithProvider(MineSweeper))
+    expect(screen.queryByText('Custom Field')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('Custom...'))
+
+    expect(screen.getByText('Custom Field')).toBeInTheDocument()
+  })
+
   it('starts a new game when the face is clicked after game over', async () => {
     render(renderWithProvider(MineSweeper))
     const loseFace = await screen.findByAltText('x-eyes face')

--- a/apps/web/src/components/board/Board.test.tsx
+++ b/apps/web/src/components/board/Board.test.tsx
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw'
 import { renderWithProvider } from '../../renderWithProvider'
 import { MineSweeper } from './MineSweeper'
 import { server } from '../../service/mocks/server'
+import { useFlagStore } from '../../common/store/useFlagStore'
 import { type Board as BoardT } from '../../utils/generateMinesweeperGrid'
 
 const makeBoard = (id: string, overrides: Partial<BoardT> = {}): BoardT => ({
@@ -27,6 +28,7 @@ describe('Board', () => {
         return HttpResponse.json(makeBoard(id, id === 'board-1' ? { end: 'now' } : {}))
       }),
     )
+    useFlagStore.setState({ color: true, marks: true })
   })
 
   it('shows the window title bar and menu bar', () => {
@@ -67,6 +69,16 @@ describe('Board', () => {
 
     fireEvent.mouseUp(field)
     expect(screen.getByAltText('smiling face')).toBeInTheDocument()
+  })
+
+  it('renders the window in grayscale when Color is turned off', () => {
+    render(renderWithProvider(MineSweeper))
+    const win = document.querySelector('.minesweeper') as HTMLElement
+    expect(win.classList.contains('grayscale')).toBe(false)
+
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('Color'))
+    expect(win.classList.contains('grayscale')).toBe(true)
   })
 
   // These select a difficulty, which evicts the shared 'board/new' cache — keep

--- a/apps/web/src/components/board/Board.test.tsx
+++ b/apps/web/src/components/board/Board.test.tsx
@@ -55,6 +55,20 @@ describe('Board', () => {
     await waitFor(() => expect(screen.getByAltText('smiling face')).toBeInTheDocument())
   })
 
+  it('shows the surprised face while the field is pressed', async () => {
+    render(renderWithProvider(MineSweeper))
+    // Start a fresh, in-progress board so the game-over face isn't showing.
+    fireEvent.click(document.querySelector('.observerFace') as HTMLElement)
+    await screen.findByAltText('smiling face')
+
+    const field = document.querySelector('.field') as HTMLElement
+    fireEvent.mouseDown(field)
+    expect(screen.getByAltText('surprised face')).toBeInTheDocument()
+
+    fireEvent.mouseUp(field)
+    expect(screen.getByAltText('smiling face')).toBeInTheDocument()
+  })
+
   // These select a difficulty, which evicts the shared 'board/new' cache — keep
   // them last so they don't disturb the board-content tests above.
   const menuCheckFor = (label: string) =>

--- a/apps/web/src/components/board/Board.tsx
+++ b/apps/web/src/components/board/Board.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import { useIsMutating } from '@tanstack/react-query'
 import { MineField } from './MineField'
 import { MinesCounter } from './MinesCounter'
 import { TimerCounter } from './TimerCounter'
@@ -18,6 +20,10 @@ interface BoardProps {
 export const Board = ({ options }: BoardProps) => {
   const { result, changeBoard } = useBoard(options)
   const { data, isFetched } = result
+  // Surprised face: from the moment a cell is pressed (`pressing`) through the
+  // in-flight reveal mutation, until the API responds with the new board state.
+  const [pressing, setPressing] = useState(false)
+  const isRevealing = useIsMutating() > 0
   const board: BoardT = isFetched
     ? data
     : {
@@ -32,10 +38,15 @@ export const Board = ({ options }: BoardProps) => {
     <div className="board">
       <div className="header">
         <MinesCounter board={board} />
-        <ObserverFace board={data} changeBoard={changeBoard} />
+        <ObserverFace board={data} changeBoard={changeBoard} pending={pressing || isRevealing} />
         <TimerCounter start={data?.start} end={data?.end} />
       </div>
-      <MineField key={data?.id || 'new'} board={board} />
+      <MineField
+        key={data?.id || 'new'}
+        board={board}
+        onPressStart={() => setPressing(true)}
+        onPressEnd={() => setPressing(false)}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/board/Cell.tsx
+++ b/apps/web/src/components/board/Cell.tsx
@@ -19,7 +19,7 @@ export const Cell: FC<CellProps> = ({
   boardId,
   isGameOver,
 }) => {
-  const { mutate } = useBoardMutation()
+  const { mutate } = useBoardMutation(boardId)
   const [pressTimer, setPressTimer] = useState<NodeJS.Timeout | undefined>(undefined)
 
   const key = `${position.x}:${position.y}`

--- a/apps/web/src/components/board/CustomField.test.tsx
+++ b/apps/web/src/components/board/CustomField.test.tsx
@@ -31,7 +31,7 @@ describe('CustomField', () => {
     render(<CustomField onSubmit={onSubmit} onClose={onClose} />)
 
     fireEvent.click(screen.getByText('Cancel'))
-    fireEvent.click(screen.getByText('✕'))
+    fireEvent.click(screen.getByAltText('close'))
 
     expect(onClose).toHaveBeenCalledTimes(2)
     expect(onSubmit).not.toHaveBeenCalled()

--- a/apps/web/src/components/board/CustomField.test.tsx
+++ b/apps/web/src/components/board/CustomField.test.tsx
@@ -3,7 +3,7 @@ import { CustomField } from './CustomField'
 
 describe('CustomField', () => {
   it('renders the Height, Width and Mines fields with defaults', () => {
-    render(<CustomField onClose={vi.fn()} />)
+    render(<CustomField onSubmit={vi.fn()} onClose={vi.fn()} />)
     expect(screen.getByText('Height:')).toBeInTheDocument()
     expect(screen.getByText('Width:')).toBeInTheDocument()
     expect(screen.getByText('Mines:')).toBeInTheDocument()
@@ -13,23 +13,27 @@ describe('CustomField', () => {
     expect(values).toEqual(['8', '8', '10'])
   })
 
-  it('updates each field when edited', () => {
-    render(<CustomField onClose={vi.fn()} />)
+  it('submits the entered dimensions as options when OK is clicked', () => {
+    const onSubmit = vi.fn()
+    render(<CustomField onSubmit={onSubmit} onClose={vi.fn()} />)
     const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
     fireEvent.change(inputs[0], { target: { value: '16' } })
     fireEvent.change(inputs[1], { target: { value: '30' } })
     fireEvent.change(inputs[2], { target: { value: '99' } })
-    expect(Array.from(inputs).map((input) => input.value)).toEqual(['16', '30', '99'])
-  })
-
-  it('calls onClose from OK, Cancel and the title-bar close button', () => {
-    const onClose = vi.fn()
-    render(<CustomField onClose={onClose} />)
 
     fireEvent.click(screen.getByText('OK'))
+    expect(onSubmit).toHaveBeenCalledWith({ rows: 16, cells: 30, mines: 99 })
+  })
+
+  it('closes without submitting from Cancel and the title-bar close button', () => {
+    const onSubmit = vi.fn()
+    const onClose = vi.fn()
+    render(<CustomField onSubmit={onSubmit} onClose={onClose} />)
+
     fireEvent.click(screen.getByText('Cancel'))
     fireEvent.click(screen.getByText('✕'))
 
-    expect(onClose).toHaveBeenCalledTimes(3)
+    expect(onClose).toHaveBeenCalledTimes(2)
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/board/CustomField.test.tsx
+++ b/apps/web/src/components/board/CustomField.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CustomField } from './CustomField'
+
+describe('CustomField', () => {
+  it('renders the Height, Width and Mines fields with defaults', () => {
+    render(<CustomField onClose={vi.fn()} />)
+    expect(screen.getByText('Height:')).toBeInTheDocument()
+    expect(screen.getByText('Width:')).toBeInTheDocument()
+    expect(screen.getByText('Mines:')).toBeInTheDocument()
+
+    const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
+    const values = Array.from(inputs).map((input) => input.value)
+    expect(values).toEqual(['8', '8', '10'])
+  })
+
+  it('updates each field when edited', () => {
+    render(<CustomField onClose={vi.fn()} />)
+    const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
+    fireEvent.change(inputs[0], { target: { value: '16' } })
+    fireEvent.change(inputs[1], { target: { value: '30' } })
+    fireEvent.change(inputs[2], { target: { value: '99' } })
+    expect(Array.from(inputs).map((input) => input.value)).toEqual(['16', '30', '99'])
+  })
+
+  it('calls onClose from OK, Cancel and the title-bar close button', () => {
+    const onClose = vi.fn()
+    render(<CustomField onClose={onClose} />)
+
+    fireEvent.click(screen.getByText('OK'))
+    fireEvent.click(screen.getByText('Cancel'))
+    fireEvent.click(screen.getByText('✕'))
+
+    expect(onClose).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/web/src/components/board/CustomField.test.tsx
+++ b/apps/web/src/components/board/CustomField.test.tsx
@@ -18,11 +18,33 @@ describe('CustomField', () => {
     render(<CustomField onSubmit={onSubmit} onClose={vi.fn()} />)
     const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
     fireEvent.change(inputs[0], { target: { value: '16' } })
-    fireEvent.change(inputs[1], { target: { value: '30' } })
-    fireEvent.change(inputs[2], { target: { value: '99' } })
+    fireEvent.change(inputs[1], { target: { value: '20' } })
+    fireEvent.change(inputs[2], { target: { value: '40' } })
 
     fireEvent.click(screen.getByText('OK'))
-    expect(onSubmit).toHaveBeenCalledWith({ rows: 16, cells: 30, mines: 99 })
+    expect(onSubmit).toHaveBeenCalledWith({ rows: 16, cells: 20, mines: 40 })
+  })
+
+  it('clamps oversized values: height to 30, width to 24, mines to width*height-1', () => {
+    const onSubmit = vi.fn()
+    render(<CustomField onSubmit={onSubmit} onClose={vi.fn()} />)
+    const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
+    fireEvent.change(inputs[0], { target: { value: '999' } }) // height -> 30
+    fireEvent.change(inputs[1], { target: { value: '999' } }) // width -> 24
+    fireEvent.change(inputs[2], { target: { value: '99999' } }) // mines -> 30*24-1
+
+    fireEvent.click(screen.getByText('OK'))
+    expect(onSubmit).toHaveBeenCalledWith({ rows: 30, cells: 24, mines: 30 * 24 - 1 })
+  })
+
+  it('raises fewer than 10 mines up to the minimum of 10', () => {
+    const onSubmit = vi.fn()
+    render(<CustomField onSubmit={onSubmit} onClose={vi.fn()} />)
+    const inputs = document.querySelectorAll<HTMLInputElement>('.customFieldRow input')
+    fireEvent.change(inputs[2], { target: { value: '3' } }) // mines -> 10
+
+    fireEvent.click(screen.getByText('OK'))
+    expect(onSubmit).toHaveBeenCalledWith({ rows: 8, cells: 8, mines: 10 })
   })
 
   it('closes without submitting from Cancel and the title-bar close button', () => {

--- a/apps/web/src/components/board/CustomField.tsx
+++ b/apps/web/src/components/board/CustomField.tsx
@@ -1,16 +1,21 @@
 import { useState } from 'react'
+import { type Options } from '../../utils/generateMinesweeperGrid'
 import { Window } from '../../common/components/Window'
 
 type CustomFieldProps = {
+  onSubmit: (options: Options) => void
   onClose: () => void
 }
 
-// The classic "Custom Field" dialog. Inputs are editable but visual only —
-// OK, Cancel, and the title-bar close button all simply dismiss the dialog.
-export const CustomField = ({ onClose }: CustomFieldProps) => {
+// The classic "Custom Field" dialog. OK applies the entered dimensions as a new
+// board; Cancel and the title-bar close button dismiss it without changes.
+export const CustomField = ({ onSubmit, onClose }: CustomFieldProps) => {
   const [height, setHeight] = useState('8')
   const [width, setWidth] = useState('8')
   const [mines, setMines] = useState('10')
+
+  const handleOk = () =>
+    onSubmit({ rows: Number(height), cells: Number(width), mines: Number(mines) })
 
   return (
     <Window title="Custom Field" variant="dialog" onClose={onClose}>
@@ -18,19 +23,24 @@ export const CustomField = ({ onClose }: CustomFieldProps) => {
         <div className="customFieldFields">
           <label className="customFieldRow">
             <span>Height:</span>
-            <input value={height} onChange={(e) => setHeight(e.target.value)} />
+            <input
+              type="number"
+              min="1"
+              value={height}
+              onChange={(e) => setHeight(e.target.value)}
+            />
           </label>
           <label className="customFieldRow">
             <span>Width:</span>
-            <input value={width} onChange={(e) => setWidth(e.target.value)} />
+            <input type="number" min="1" value={width} onChange={(e) => setWidth(e.target.value)} />
           </label>
           <label className="customFieldRow">
             <span>Mines:</span>
-            <input value={mines} onChange={(e) => setMines(e.target.value)} />
+            <input type="number" min="1" value={mines} onChange={(e) => setMines(e.target.value)} />
           </label>
         </div>
         <div className="customFieldButtons">
-          <button className="windowButton dialogButton" onClick={onClose}>
+          <button className="windowButton dialogButton" onClick={handleOk}>
             OK
           </button>
           <button className="windowButton dialogButton" onClick={onClose}>

--- a/apps/web/src/components/board/CustomField.tsx
+++ b/apps/web/src/components/board/CustomField.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Window } from '../../common/components/Window'
+
+type CustomFieldProps = {
+  onClose: () => void
+}
+
+// The classic "Custom Field" dialog. Inputs are editable but visual only —
+// OK, Cancel, and the title-bar close button all simply dismiss the dialog.
+export const CustomField = ({ onClose }: CustomFieldProps) => {
+  const [height, setHeight] = useState('8')
+  const [width, setWidth] = useState('8')
+  const [mines, setMines] = useState('10')
+
+  return (
+    <Window title="Custom Field" variant="dialog" onClose={onClose}>
+      <div className="customFieldBody">
+        <div className="customFieldFields">
+          <label className="customFieldRow">
+            <span>Height:</span>
+            <input value={height} onChange={(e) => setHeight(e.target.value)} />
+          </label>
+          <label className="customFieldRow">
+            <span>Width:</span>
+            <input value={width} onChange={(e) => setWidth(e.target.value)} />
+          </label>
+          <label className="customFieldRow">
+            <span>Mines:</span>
+            <input value={mines} onChange={(e) => setMines(e.target.value)} />
+          </label>
+        </div>
+        <div className="customFieldButtons">
+          <button className="windowButton dialogButton" onClick={onClose}>
+            OK
+          </button>
+          <button className="windowButton dialogButton" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Window>
+  )
+}

--- a/apps/web/src/components/board/CustomField.tsx
+++ b/apps/web/src/components/board/CustomField.tsx
@@ -7,6 +7,13 @@ type CustomFieldProps = {
   onClose: () => void
 }
 
+const MAX_HEIGHT = 30
+const MAX_WIDTH = 24
+const MIN_MINES = 10
+
+const clamp = (value: string, min: number, max: number) =>
+  Math.min(Math.max(Math.floor(Number(value)) || min, min), max)
+
 // The classic "Custom Field" dialog. OK applies the entered dimensions as a new
 // board; Cancel and the title-bar close button dismiss it without changes.
 export const CustomField = ({ onSubmit, onClose }: CustomFieldProps) => {
@@ -14,8 +21,13 @@ export const CustomField = ({ onSubmit, onClose }: CustomFieldProps) => {
   const [width, setWidth] = useState('8')
   const [mines, setMines] = useState('10')
 
-  const handleOk = () =>
-    onSubmit({ rows: Number(height), cells: Number(width), mines: Number(mines) })
+  // Out-of-range values fall back to the limits: up to 30 rows and 24 columns,
+  // and between 10 mines and one fewer than there are cells.
+  const handleOk = () => {
+    const rows = clamp(height, 1, MAX_HEIGHT)
+    const cells = clamp(width, 1, MAX_WIDTH)
+    onSubmit({ rows, cells, mines: clamp(mines, MIN_MINES, rows * cells - 1) })
+  }
 
   return (
     <Window title="Custom Field" variant="dialog" onClose={onClose}>

--- a/apps/web/src/components/board/HelpWindow.test.tsx
+++ b/apps/web/src/components/board/HelpWindow.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HelpWindow } from './HelpWindow'
+
+describe('HelpWindow', () => {
+  it('renders help content', () => {
+    render(<HelpWindow onClose={vi.fn()} />)
+    expect(screen.getByText('Help')).toBeInTheDocument()
+    expect(screen.getByText(/Left-click a cell/)).toBeInTheDocument()
+  })
+
+  it('closes from OK and the title-bar close button', () => {
+    const onClose = vi.fn()
+    render(<HelpWindow onClose={onClose} />)
+
+    fireEvent.click(screen.getByText('OK'))
+    fireEvent.click(screen.getByAltText('close'))
+
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/components/board/HelpWindow.tsx
+++ b/apps/web/src/components/board/HelpWindow.tsx
@@ -1,0 +1,27 @@
+import { Window } from '../../common/components/Window'
+
+type HelpWindowProps = {
+  onClose: () => void
+}
+
+// A small Help dialog, opened from the "Help" menu or the H shortcut.
+export const HelpWindow = ({ onClose }: HelpWindowProps) => {
+  return (
+    <Window title="Help" variant="dialog" onClose={onClose}>
+      <div className="helpBody">
+        <p>Clear every cell that isn&apos;t a mine.</p>
+        <ul>
+          <li>Left-click a cell to reveal it.</li>
+          <li>Right-click to flag a mine — again for a ? when Marks is on.</li>
+          <li>A number is how many mines touch that cell.</li>
+          <li>Click the face (or press F2) to start a new game.</li>
+        </ul>
+        <div className="helpButtons">
+          <button className="windowButton dialogButton" onClick={onClose}>
+            OK
+          </button>
+        </div>
+      </div>
+    </Window>
+  )
+}

--- a/apps/web/src/components/board/MineField.test.tsx
+++ b/apps/web/src/components/board/MineField.test.tsx
@@ -1,0 +1,33 @@
+import { render, fireEvent } from '@testing-library/react'
+import { MineField } from './MineField'
+import { type Board } from '../../utils/generateMinesweeperGrid'
+
+// An empty field renders no cells, so no query provider is needed.
+const board: Board = {
+  id: 'b',
+  options: { rows: 0, cells: 0, mines: 0 },
+  field: [],
+  start: null,
+  end: null,
+  win: false,
+}
+
+describe('MineField', () => {
+  it('signals press start on mouse/touch down and press end on up, leave and touch end', () => {
+    const onPressStart = vi.fn()
+    const onPressEnd = vi.fn()
+    const { container } = render(
+      <MineField board={board} onPressStart={onPressStart} onPressEnd={onPressEnd} />,
+    )
+    const field = container.querySelector('.field') as HTMLElement
+
+    fireEvent.mouseDown(field)
+    fireEvent.touchStart(field)
+    expect(onPressStart).toHaveBeenCalledTimes(2)
+
+    fireEvent.mouseUp(field)
+    fireEvent.mouseLeave(field)
+    fireEvent.touchEnd(field)
+    expect(onPressEnd).toHaveBeenCalledTimes(3)
+  })
+})

--- a/apps/web/src/components/board/MineField.tsx
+++ b/apps/web/src/components/board/MineField.tsx
@@ -4,12 +4,22 @@ import { FC } from 'react'
 
 interface MineFieldProps {
   board: Board
+  // Pressing a cell shows the surprised face; releasing (a click) reveals it.
+  onPressStart?: () => void
+  onPressEnd?: () => void
 }
 
-export const MineField: FC<MineFieldProps> = ({ board }) => {
+export const MineField: FC<MineFieldProps> = ({ board, onPressStart, onPressEnd }) => {
   const { field, id, end } = board
   return (
-    <div className="field">
+    <div
+      className="field"
+      onMouseDown={onPressStart}
+      onMouseUp={onPressEnd}
+      onMouseLeave={onPressEnd}
+      onTouchStart={onPressStart}
+      onTouchEnd={onPressEnd}
+    >
       {field?.map((row, y) => (
         <Row key={`${id}:${y}`} cells={row} y={y} boardId={id} isGameOver={end != null} />
       ))}

--- a/apps/web/src/components/board/MineSweeper.tsx
+++ b/apps/web/src/components/board/MineSweeper.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
 import './minesweeper.css'
+import windowIcon from '../../assets/window-icon.svg'
+import { Window } from '../../common/components/Window'
 import { WindowBar } from './WindowBar'
+import { CustomField } from './CustomField'
 import { Board } from './Board'
 
 const defaultOptions = {
@@ -9,10 +13,15 @@ const defaultOptions = {
 }
 
 export const MineSweeper = () => {
+  const [customOpen, setCustomOpen] = useState(false)
+
   return (
     <div className="minesweeper">
-      <WindowBar />
-      <Board options={defaultOptions} />
+      <Window title="Minesweeper" icon={windowIcon}>
+        <WindowBar onCustom={() => setCustomOpen(true)} />
+        <Board options={defaultOptions} />
+      </Window>
+      {customOpen && <CustomField onClose={() => setCustomOpen(false)} />}
     </div>
   )
 }

--- a/apps/web/src/components/board/MineSweeper.tsx
+++ b/apps/web/src/components/board/MineSweeper.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import './minesweeper.css'
 import windowIcon from '../../assets/window-icon.svg'
 import { type Options } from '../../utils/generateMinesweeperGrid'
+import { useFlagStore } from '../../common/store/useFlagStore'
 import { Window } from '../../common/components/Window'
 import { WindowBar } from './WindowBar'
 import { CustomField } from './CustomField'
@@ -17,6 +18,7 @@ const presets: Record<string, Options> = {
 
 export const MineSweeper = () => {
   const queryClient = useQueryClient()
+  const color = useFlagStore((state) => state.color)
   const [options, setOptions] = useState<Options>(presets.Beginner)
   const [difficulty, setDifficulty] = useState('Beginner')
   const [generation, setGeneration] = useState(0)
@@ -46,7 +48,7 @@ export const MineSweeper = () => {
   }
 
   return (
-    <div className="minesweeper">
+    <div className={`minesweeper${color ? '' : ' grayscale'}`}>
       <Window title="Minesweeper" icon={windowIcon}>
         <WindowBar onSelect={handleSelect} activeDifficulty={difficulty} />
         <Board key={generation} options={options} />

--- a/apps/web/src/components/board/MineSweeper.tsx
+++ b/apps/web/src/components/board/MineSweeper.tsx
@@ -1,27 +1,57 @@
 import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import './minesweeper.css'
 import windowIcon from '../../assets/window-icon.svg'
+import { type Options } from '../../utils/generateMinesweeperGrid'
 import { Window } from '../../common/components/Window'
 import { WindowBar } from './WindowBar'
 import { CustomField } from './CustomField'
 import { Board } from './Board'
 
-const defaultOptions = {
-  cells: 9,
-  rows: 9,
-  mines: 10,
+// Classic difficulty presets: `rows` is the board height, `cells` the width.
+const presets: Record<string, Options> = {
+  Beginner: { rows: 9, cells: 9, mines: 10 },
+  Intermediate: { rows: 16, cells: 16, mines: 40 },
+  Expert: { rows: 16, cells: 30, mines: 99 },
 }
 
 export const MineSweeper = () => {
+  const queryClient = useQueryClient()
+  const [options, setOptions] = useState<Options>(presets.Beginner)
+  const [difficulty, setDifficulty] = useState('Beginner')
+  const [generation, setGeneration] = useState(0)
   const [customOpen, setCustomOpen] = useState(false)
+
+  // Start a fresh board of the given size. Remounting Board (via the changed
+  // key) resets its query id to 'new', and dropping the cached 'new' board
+  // forces a refetch so the mock regenerates the field at the new dimensions.
+  const startGame = (label: string, newOptions: Options) => {
+    setOptions(newOptions)
+    setDifficulty(label)
+    queryClient.removeQueries({ queryKey: ['board', 'new'] })
+    setGeneration((value) => value + 1)
+  }
+
+  const handleSelect = (label: string) => {
+    if (label === 'Custom...') {
+      setCustomOpen(true)
+      return
+    }
+    if (presets[label]) startGame(label, presets[label])
+  }
+
+  const applyCustom = (newOptions: Options) => {
+    setCustomOpen(false)
+    startGame('Custom...', newOptions)
+  }
 
   return (
     <div className="minesweeper">
       <Window title="Minesweeper" icon={windowIcon}>
-        <WindowBar onCustom={() => setCustomOpen(true)} />
-        <Board options={defaultOptions} />
+        <WindowBar onSelect={handleSelect} activeDifficulty={difficulty} />
+        <Board key={generation} options={options} />
       </Window>
-      {customOpen && <CustomField onClose={() => setCustomOpen(false)} />}
+      {customOpen && <CustomField onSubmit={applyCustom} onClose={() => setCustomOpen(false)} />}
     </div>
   )
 }

--- a/apps/web/src/components/board/MineSweeper.tsx
+++ b/apps/web/src/components/board/MineSweeper.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import './minesweeper.css'
 import windowIcon from '../../assets/window-icon.svg'
@@ -7,6 +7,8 @@ import { useFlagStore } from '../../common/store/useFlagStore'
 import { Window } from '../../common/components/Window'
 import { WindowBar } from './WindowBar'
 import { CustomField } from './CustomField'
+import { HelpWindow } from './HelpWindow'
+import { AboutWindow } from './AboutWindow'
 import { Board } from './Board'
 
 // Classic difficulty presets: `rows` is the board height, `cells` the width.
@@ -23,20 +25,53 @@ export const MineSweeper = () => {
   const [difficulty, setDifficulty] = useState('Beginner')
   const [generation, setGeneration] = useState(0)
   const [customOpen, setCustomOpen] = useState(false)
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [aboutOpen, setAboutOpen] = useState(false)
 
   // Start a fresh board of the given size. Remounting Board (via the changed
   // key) resets its query id to 'new', and dropping the cached 'new' board
   // forces a refetch so the mock regenerates the field at the new dimensions.
-  const startGame = (label: string, newOptions: Options) => {
-    setOptions(newOptions)
-    setDifficulty(label)
-    queryClient.removeQueries({ queryKey: ['board', 'new'] })
-    setGeneration((value) => value + 1)
-  }
+  const startGame = useCallback(
+    (label: string, newOptions: Options) => {
+      setOptions(newOptions)
+      setDifficulty(label)
+      queryClient.removeQueries({ queryKey: ['board', 'new'] })
+      setGeneration((value) => value + 1)
+    },
+    [queryClient],
+  )
+
+  // F2 starts a new game (Game/Help menu accelerators live in WindowBar).
+  // Ignore keystrokes aimed at a text field (e.g. the Custom Field inputs).
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const tag = (event.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      if (event.key === 'F2') {
+        event.preventDefault()
+        startGame(difficulty, options)
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [difficulty, options, startGame])
 
   const handleSelect = (label: string) => {
+    if (label === 'New') {
+      // Restart the current difficulty — same as clicking the reset face.
+      startGame(difficulty, options)
+      return
+    }
     if (label === 'Custom...') {
       setCustomOpen(true)
+      return
+    }
+    if (label === 'Help Topics') {
+      setHelpOpen(true)
+      return
+    }
+    if (label === 'About Minesweeper') {
+      setAboutOpen(true)
       return
     }
     if (presets[label]) startGame(label, presets[label])
@@ -54,6 +89,8 @@ export const MineSweeper = () => {
         <Board key={generation} options={options} />
       </Window>
       {customOpen && <CustomField onSubmit={applyCustom} onClose={() => setCustomOpen(false)} />}
+      {helpOpen && <HelpWindow onClose={() => setHelpOpen(false)} />}
+      {aboutOpen && <AboutWindow onClose={() => setAboutOpen(false)} />}
     </div>
   )
 }

--- a/apps/web/src/components/board/ObserverFace.test.tsx
+++ b/apps/web/src/components/board/ObserverFace.test.tsx
@@ -33,6 +33,18 @@ describe('ObserverFace', () => {
     expect(screen.getByAltText('x-eyes face')).toBeInTheDocument()
   })
 
+  it('shows the surprised face while a move is pending', () => {
+    render(<ObserverFace board={makeBoard()} changeBoard={vi.fn()} pending />)
+    expect(screen.getByAltText('surprised face')).toBeInTheDocument()
+  })
+
+  it('shows the game-over face rather than surprised once the game has ended', () => {
+    render(
+      <ObserverFace board={makeBoard({ end: 'now', win: false })} changeBoard={vi.fn()} pending />,
+    )
+    expect(screen.getByAltText('x-eyes face')).toBeInTheDocument()
+  })
+
   it('starts a new board on click', () => {
     const changeBoard = vi.fn().mockResolvedValue(undefined)
     render(<ObserverFace board={makeBoard()} changeBoard={changeBoard} />)

--- a/apps/web/src/components/board/ObserverFace.tsx
+++ b/apps/web/src/components/board/ObserverFace.tsx
@@ -2,20 +2,31 @@ import { type Board } from '../../utils/generateMinesweeperGrid'
 import defaultFaceIcon from '../../assets/face-default.svg'
 import winFaceIcon from '../../assets/face-win.svg'
 import loseFaceIcon from '../../assets/face-lose.svg'
+import surprisedFaceIcon from '../../assets/face-surprised.svg'
 
 const faces = {
   default: { src: defaultFaceIcon, alt: 'smiling face' },
   win: { src: winFaceIcon, alt: 'sunglasses face' },
   lose: { src: loseFaceIcon, alt: 'x-eyes face' },
+  surprised: { src: surprisedFaceIcon, alt: 'surprised face' },
 }
 
 interface ObserverFaceProps {
   board: Board
   changeBoard: (id: string) => Promise<void>
+  // True while a move is being processed — shows the surprised face until the
+  // API responds with the new board state.
+  pending?: boolean
 }
-export const ObserverFace = ({ board, changeBoard }: ObserverFaceProps) => {
+export const ObserverFace = ({ board, changeBoard, pending }: ObserverFaceProps) => {
   const isGameOver = board?.end != null
-  const face = isGameOver ? (board.win ? faces.win : faces.lose) : faces.default
+  const face = isGameOver
+    ? board.win
+      ? faces.win
+      : faces.lose
+    : pending
+      ? faces.surprised
+      : faces.default
   return (
     <div
       className="observerFace"

--- a/apps/web/src/components/board/WindowBar.test.tsx
+++ b/apps/web/src/components/board/WindowBar.test.tsx
@@ -1,7 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { WindowBar } from './WindowBar'
+import { useFlagStore } from '../../common/store/useFlagStore'
+
+const markCheckFor = (label: string) =>
+  screen.getByText(label).closest('.menuDropdownItem')?.querySelector('.menuCheck')?.textContent
 
 describe('WindowBar', () => {
+  beforeEach(() => useFlagStore.setState({ marks: true }))
+
   it('keeps the Game dropdown closed by default', () => {
     render(<WindowBar />)
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
@@ -71,5 +77,19 @@ describe('WindowBar', () => {
     fireEvent.click(screen.getByText('Custom...'))
 
     expect(onSelect).toHaveBeenCalledWith('Custom...')
+  })
+
+  it('toggles the Marks (?) option without firing onSelect', () => {
+    const onSelect = vi.fn()
+    render(<WindowBar onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('Game'))
+    expect(markCheckFor('Marks (?)')).toBe('✓')
+
+    fireEvent.click(screen.getByText('Marks (?)'))
+    expect(useFlagStore.getState().marks).toBe(false)
+    expect(onSelect).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('Game'))
+    expect(markCheckFor('Marks (?)')).toBe('')
   })
 })

--- a/apps/web/src/components/board/WindowBar.test.tsx
+++ b/apps/web/src/components/board/WindowBar.test.tsx
@@ -93,6 +93,54 @@ describe('WindowBar', () => {
     expect(markCheckFor('Marks (?)')).toBe('')
   })
 
+  it('opens the Game dropdown with the G key', () => {
+    render(<WindowBar />)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'g' })
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+  })
+
+  it('opens the Help dropdown on click with its entries', () => {
+    const onSelect = vi.fn()
+    render(<WindowBar onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('Help'))
+
+    const labels = screen
+      .getAllByRole('menuitem')
+      .map((item) => item.querySelector('.menuLabel')?.textContent)
+    expect(labels).toEqual(['Help Topics', 'About Minesweeper'])
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('fires onSelect for Help Topics and About Minesweeper', () => {
+    const onSelect = vi.fn()
+    render(<WindowBar onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('Help'))
+    fireEvent.click(screen.getByText('Help Topics'))
+    expect(onSelect).toHaveBeenCalledWith('Help Topics')
+
+    fireEvent.click(screen.getByText('Help'))
+    fireEvent.click(screen.getByText('About Minesweeper'))
+    expect(onSelect).toHaveBeenCalledWith('About Minesweeper')
+  })
+
+  it('opens the Help dropdown with the H key', () => {
+    render(<WindowBar />)
+    fireEvent.keyDown(document, { key: 'h' })
+    expect(screen.getByText('Help Topics')).toBeInTheDocument()
+  })
+
+  it('opens only one menu at a time, and F2 closes any open menu', () => {
+    render(<WindowBar />)
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.keyDown(document, { key: 'h' })
+    expect(screen.queryByText('New')).not.toBeInTheDocument()
+    expect(screen.getByText('Help Topics')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'F2' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
   it('toggles the Color option without firing onSelect', () => {
     const onSelect = vi.fn()
     render(<WindowBar onSelect={onSelect} />)

--- a/apps/web/src/components/board/WindowBar.test.tsx
+++ b/apps/web/src/components/board/WindowBar.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { WindowBar } from './WindowBar'
+
+describe('WindowBar', () => {
+  it('keeps the Game dropdown closed by default', () => {
+    render(<WindowBar />)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('opens the Game dropdown on click with the expected entries', () => {
+    render(<WindowBar />)
+    fireEvent.click(screen.getByText('Game'))
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    const labels = screen
+      .getAllByRole('menuitem')
+      .map((item) => item.querySelector('.menuLabel')?.textContent)
+    expect(labels).toEqual([
+      'New',
+      'Beginner',
+      'Intermediate',
+      'Expert',
+      'Custom...',
+      'Marks (?)',
+      'Color',
+      'Best Times...',
+      'Exit',
+    ])
+  })
+
+  it('checks Beginner, Marks and Color, and shows the New shortcut', () => {
+    render(<WindowBar />)
+    fireEvent.click(screen.getByText('Game'))
+
+    const checked = screen
+      .getAllByRole('menuitem')
+      .filter((item) => item.querySelector('.menuCheck')?.textContent === '✓')
+      .map((item) => item.querySelector('.menuLabel')?.textContent)
+    expect(checked).toEqual(['Beginner', 'Marks (?)', 'Color'])
+    expect(screen.getByText('F2')).toBeInTheDocument()
+  })
+
+  it('toggles the dropdown closed on a second Game click', () => {
+    render(<WindowBar />)
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('Game'))
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('closes the dropdown when clicking outside', () => {
+    render(<WindowBar />)
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('fires onCustom and closes the dropdown when Custom... is clicked', () => {
+    const onCustom = vi.fn()
+    render(<WindowBar onCustom={onCustom} />)
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('Custom...'))
+
+    expect(onCustom).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/board/WindowBar.test.tsx
+++ b/apps/web/src/components/board/WindowBar.test.tsx
@@ -28,15 +28,15 @@ describe('WindowBar', () => {
     ])
   })
 
-  it('checks Beginner, Marks and Color, and shows the New shortcut', () => {
-    render(<WindowBar />)
+  it('checks the active difficulty alongside Marks and Color, and shows the shortcut', () => {
+    render(<WindowBar activeDifficulty="Expert" />)
     fireEvent.click(screen.getByText('Game'))
 
     const checked = screen
       .getAllByRole('menuitem')
       .filter((item) => item.querySelector('.menuCheck')?.textContent === '✓')
       .map((item) => item.querySelector('.menuLabel')?.textContent)
-    expect(checked).toEqual(['Beginner', 'Marks (?)', 'Color'])
+    expect(checked).toEqual(['Expert', 'Marks (?)', 'Color'])
     expect(screen.getByText('F2')).toBeInTheDocument()
   })
 
@@ -54,13 +54,22 @@ describe('WindowBar', () => {
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
 
-  it('fires onCustom and closes the dropdown when Custom... is clicked', () => {
-    const onCustom = vi.fn()
-    render(<WindowBar onCustom={onCustom} />)
+  it('fires onSelect with the chosen entry and closes the dropdown', () => {
+    const onSelect = vi.fn()
+    render(<WindowBar onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('Game'))
+    fireEvent.click(screen.getByText('Expert'))
+
+    expect(onSelect).toHaveBeenCalledWith('Expert')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('fires onSelect with "Custom..." when Custom is clicked', () => {
+    const onSelect = vi.fn()
+    render(<WindowBar onSelect={onSelect} />)
     fireEvent.click(screen.getByText('Game'))
     fireEvent.click(screen.getByText('Custom...'))
 
-    expect(onCustom).toHaveBeenCalledTimes(1)
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(onSelect).toHaveBeenCalledWith('Custom...')
   })
 })

--- a/apps/web/src/components/board/WindowBar.test.tsx
+++ b/apps/web/src/components/board/WindowBar.test.tsx
@@ -6,7 +6,7 @@ const markCheckFor = (label: string) =>
   screen.getByText(label).closest('.menuDropdownItem')?.querySelector('.menuCheck')?.textContent
 
 describe('WindowBar', () => {
-  beforeEach(() => useFlagStore.setState({ marks: true }))
+  beforeEach(() => useFlagStore.setState({ marks: true, color: true }))
 
   it('keeps the Game dropdown closed by default', () => {
     render(<WindowBar />)
@@ -91,5 +91,19 @@ describe('WindowBar', () => {
 
     fireEvent.click(screen.getByText('Game'))
     expect(markCheckFor('Marks (?)')).toBe('')
+  })
+
+  it('toggles the Color option without firing onSelect', () => {
+    const onSelect = vi.fn()
+    render(<WindowBar onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('Game'))
+    expect(markCheckFor('Color')).toBe('✓')
+
+    fireEvent.click(screen.getByText('Color'))
+    expect(useFlagStore.getState().color).toBe(false)
+    expect(onSelect).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByText('Game'))
+    expect(markCheckFor('Color')).toBe('')
   })
 })

--- a/apps/web/src/components/board/WindowBar.tsx
+++ b/apps/web/src/components/board/WindowBar.tsx
@@ -1,21 +1,87 @@
-import windowIcon from '../../assets/window-icon.svg'
+import { useEffect, useRef, useState } from 'react'
 
-// Decorative window chrome mimicking the classic Windows Minesweeper title
-// and menu bars. The buttons and menu entries are visual only.
-export const WindowBar = () => (
-  <div className="windowBar">
-    <div className="titleBar">
-      <img className="icon" src={windowIcon} alt="" />
-      <span className="title">Minesweeper</span>
-      <span className="windowButtons">
-        <span className="windowButton">—</span>
-        <span className="windowButton">🗖</span>
-        <span className="windowButton">✕</span>
-      </span>
-    </div>
+// Entries for the classic Windows Minesweeper "Game" dropdown. These are
+// visual only — `check` renders a leading ✓, `shortcut` right-aligns a hint,
+// and a null entry renders a separator line.
+type GameMenuEntry = {
+  label: string
+  check?: boolean
+  shortcut?: string
+} | null
+
+const gameMenuEntries: GameMenuEntry[] = [
+  { label: 'New', shortcut: 'F2' },
+  null,
+  { label: 'Beginner', check: true },
+  { label: 'Intermediate' },
+  { label: 'Expert' },
+  { label: 'Custom...' },
+  null,
+  { label: 'Marks (?)', check: true },
+  { label: 'Color', check: true },
+  null,
+  { label: 'Best Times...' },
+  null,
+  { label: 'Exit' },
+]
+
+type WindowBarProps = {
+  onCustom?: () => void
+}
+
+// The classic Windows Minesweeper menu bar with the "Game" dropdown. The
+// entries are visual only, except "Custom..." which invokes `onCustom`.
+export const WindowBar = ({ onCustom }: WindowBarProps) => {
+  const [gameMenuOpen, setGameMenuOpen] = useState(false)
+  const gameMenuRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    if (!gameMenuOpen) return
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!gameMenuRef.current?.contains(event.target as Node)) {
+        setGameMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [gameMenuOpen])
+
+  const handleSelect = (label: string) => {
+    setGameMenuOpen(false)
+    if (label === 'Custom...') onCustom?.()
+  }
+
+  return (
     <div className="menuBar">
-      <span className="menuItem">Game</span>
+      <span className="menuItemWrapper" ref={gameMenuRef}>
+        <span
+          className={`menuItem${gameMenuOpen ? ' active' : ''}`}
+          onClick={() => setGameMenuOpen((open) => !open)}
+        >
+          Game
+        </span>
+        {gameMenuOpen && (
+          <div className="menuDropdown" role="menu">
+            {gameMenuEntries.map((entry, index) =>
+              entry === null ? (
+                <div key={`separator-${index}`} className="menuSeparator" />
+              ) : (
+                <div
+                  key={entry.label}
+                  className="menuDropdownItem"
+                  role="menuitem"
+                  onClick={() => handleSelect(entry.label)}
+                >
+                  <span className="menuCheck">{entry.check ? '✓' : ''}</span>
+                  <span className="menuLabel">{entry.label}</span>
+                  <span className="menuShortcut">{entry.shortcut ?? ''}</span>
+                </div>
+              ),
+            )}
+          </div>
+        )}
+      </span>
       <span className="menuItem">Help</span>
     </div>
-  </div>
-)
+  )
+}

--- a/apps/web/src/components/board/WindowBar.tsx
+++ b/apps/web/src/components/board/WindowBar.tsx
@@ -12,7 +12,7 @@ type GameMenuEntry = {
 const gameMenuEntries: GameMenuEntry[] = [
   { label: 'New', shortcut: 'F2' },
   null,
-  { label: 'Beginner', check: true },
+  { label: 'Beginner' },
   { label: 'Intermediate' },
   { label: 'Expert' },
   { label: 'Custom...' },
@@ -25,13 +25,17 @@ const gameMenuEntries: GameMenuEntry[] = [
   { label: 'Exit' },
 ]
 
+// Difficulty entries show a ✓ against the active one instead of a static check.
+const difficultyLabels = ['Beginner', 'Intermediate', 'Expert', 'Custom...']
+
 type WindowBarProps = {
-  onCustom?: () => void
+  onSelect?: (label: string) => void
+  activeDifficulty?: string
 }
 
-// The classic Windows Minesweeper menu bar with the "Game" dropdown. The
-// entries are visual only, except "Custom..." which invokes `onCustom`.
-export const WindowBar = ({ onCustom }: WindowBarProps) => {
+// The classic Windows Minesweeper menu bar with the "Game" dropdown. Selecting
+// an entry invokes `onSelect`; the active difficulty is marked with a ✓.
+export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
   const [gameMenuOpen, setGameMenuOpen] = useState(false)
   const gameMenuRef = useRef<HTMLSpanElement>(null)
 
@@ -48,8 +52,11 @@ export const WindowBar = ({ onCustom }: WindowBarProps) => {
 
   const handleSelect = (label: string) => {
     setGameMenuOpen(false)
-    if (label === 'Custom...') onCustom?.()
+    onSelect?.(label)
   }
+
+  const isChecked = (entry: { label: string; check?: boolean }) =>
+    difficultyLabels.includes(entry.label) ? entry.label === activeDifficulty : !!entry.check
 
   return (
     <div className="menuBar">
@@ -72,7 +79,7 @@ export const WindowBar = ({ onCustom }: WindowBarProps) => {
                   role="menuitem"
                   onClick={() => handleSelect(entry.label)}
                 >
-                  <span className="menuCheck">{entry.check ? '✓' : ''}</span>
+                  <span className="menuCheck">{isChecked(entry) ? '✓' : ''}</span>
                   <span className="menuLabel">{entry.label}</span>
                   <span className="menuShortcut">{entry.shortcut ?? ''}</span>
                 </div>

--- a/apps/web/src/components/board/WindowBar.tsx
+++ b/apps/web/src/components/board/WindowBar.tsx
@@ -19,7 +19,7 @@ const gameMenuEntries: GameMenuEntry[] = [
   { label: 'Custom...' },
   null,
   { label: 'Marks (?)' },
-  { label: 'Color', check: true },
+  { label: 'Color' },
   null,
   { label: 'Best Times...' },
   null,
@@ -41,6 +41,8 @@ export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
   const gameMenuRef = useRef<HTMLSpanElement>(null)
   const marks = useFlagStore((state) => state.marks)
   const toggleMarks = useFlagStore((state) => state.toggleMarks)
+  const color = useFlagStore((state) => state.color)
+  const toggleColor = useFlagStore((state) => state.toggleColor)
 
   useEffect(() => {
     if (!gameMenuOpen) return
@@ -55,15 +57,14 @@ export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
 
   const handleSelect = (label: string) => {
     setGameMenuOpen(false)
-    if (label === 'Marks (?)') {
-      toggleMarks()
-      return
-    }
+    if (label === 'Marks (?)') return toggleMarks()
+    if (label === 'Color') return toggleColor()
     onSelect?.(label)
   }
 
   const isChecked = (entry: { label: string; check?: boolean }) => {
     if (entry.label === 'Marks (?)') return marks
+    if (entry.label === 'Color') return color
     if (difficultyLabels.includes(entry.label)) return entry.label === activeDifficulty
     return !!entry.check
   }

--- a/apps/web/src/components/board/WindowBar.tsx
+++ b/apps/web/src/components/board/WindowBar.tsx
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
 import { useFlagStore } from '../../common/store/useFlagStore'
 
-// Entries for the classic Windows Minesweeper "Game" dropdown. These are
-// visual only — `check` renders a leading ✓, `shortcut` right-aligns a hint,
-// and a null entry renders a separator line.
-type GameMenuEntry = {
+// Entries for a menu dropdown. These are visual only — `check` renders a
+// leading ✓, `shortcut` right-aligns a hint, and a null entry is a separator.
+type MenuEntry = {
   label: string
   check?: boolean
   shortcut?: string
 } | null
 
-const gameMenuEntries: GameMenuEntry[] = [
+const gameMenuEntries: MenuEntry[] = [
   { label: 'New', shortcut: 'F2' },
   null,
   { label: 'Beginner' },
@@ -26,37 +25,58 @@ const gameMenuEntries: GameMenuEntry[] = [
   { label: 'Exit' },
 ]
 
+const helpMenuEntries: MenuEntry[] = [
+  { label: 'Help Topics' },
+  null,
+  { label: 'About Minesweeper' },
+]
+
 // Difficulty entries show a ✓ against the active one instead of a static check.
 const difficultyLabels = ['Beginner', 'Intermediate', 'Expert', 'Custom...']
+
+type Menu = 'game' | 'help'
 
 type WindowBarProps = {
   onSelect?: (label: string) => void
   activeDifficulty?: string
 }
 
-// The classic Windows Minesweeper menu bar with the "Game" dropdown. Selecting
-// an entry invokes `onSelect`; the active difficulty is marked with a ✓.
+// The classic Windows Minesweeper menu bar with "Game" and "Help" dropdowns.
+// Only one is open at a time; selecting an entry invokes `onSelect`.
 export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
-  const [gameMenuOpen, setGameMenuOpen] = useState(false)
-  const gameMenuRef = useRef<HTMLSpanElement>(null)
+  const [openMenu, setOpenMenu] = useState<Menu | null>(null)
+  const menuBarRef = useRef<HTMLDivElement>(null)
   const marks = useFlagStore((state) => state.marks)
   const toggleMarks = useFlagStore((state) => state.toggleMarks)
   const color = useFlagStore((state) => state.color)
   const toggleColor = useFlagStore((state) => state.toggleColor)
 
   useEffect(() => {
-    if (!gameMenuOpen) return
+    if (!openMenu) return
     const handleClickOutside = (event: MouseEvent) => {
-      if (!gameMenuRef.current?.contains(event.target as Node)) {
-        setGameMenuOpen(false)
-      }
+      if (!menuBarRef.current?.contains(event.target as Node)) setOpenMenu(null)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [gameMenuOpen])
+  }, [openMenu])
+
+  // Accelerators: G opens the Game menu, H the Help menu; F2 (reset) closes both.
+  // Keystrokes aimed at a text field are ignored.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const tag = (event.target as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return
+      const key = event.key.toLowerCase()
+      if (key === 'g') setOpenMenu((menu) => (menu === 'game' ? null : 'game'))
+      else if (key === 'h') setOpenMenu((menu) => (menu === 'help' ? null : 'help'))
+      else if (event.key === 'F2') setOpenMenu(null)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   const handleSelect = (label: string) => {
-    setGameMenuOpen(false)
+    setOpenMenu(null)
     if (label === 'Marks (?)') return toggleMarks()
     if (label === 'Color') return toggleColor()
     onSelect?.(label)
@@ -69,37 +89,41 @@ export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
     return !!entry.check
   }
 
-  return (
-    <div className="menuBar">
-      <span className="menuItemWrapper" ref={gameMenuRef}>
-        <span
-          className={`menuItem${gameMenuOpen ? ' active' : ''}`}
-          onClick={() => setGameMenuOpen((open) => !open)}
-        >
-          Game
-        </span>
-        {gameMenuOpen && (
-          <div className="menuDropdown" role="menu">
-            {gameMenuEntries.map((entry, index) =>
-              entry === null ? (
-                <div key={`separator-${index}`} className="menuSeparator" />
-              ) : (
-                <div
-                  key={entry.label}
-                  className="menuDropdownItem"
-                  role="menuitem"
-                  onClick={() => handleSelect(entry.label)}
-                >
-                  <span className="menuCheck">{isChecked(entry) ? '✓' : ''}</span>
-                  <span className="menuLabel">{entry.label}</span>
-                  <span className="menuShortcut">{entry.shortcut ?? ''}</span>
-                </div>
-              ),
-            )}
-          </div>
-        )}
+  const renderMenu = (menu: Menu, label: string, entries: MenuEntry[]) => (
+    <span className="menuItemWrapper">
+      <span
+        className={`menuItem${openMenu === menu ? ' active' : ''}`}
+        onClick={() => setOpenMenu((current) => (current === menu ? null : menu))}
+      >
+        {label}
       </span>
-      <span className="menuItem">Help</span>
+      {openMenu === menu && (
+        <div className="menuDropdown" role="menu">
+          {entries.map((entry, index) =>
+            entry === null ? (
+              <div key={`separator-${index}`} className="menuSeparator" />
+            ) : (
+              <div
+                key={entry.label}
+                className="menuDropdownItem"
+                role="menuitem"
+                onClick={() => handleSelect(entry.label)}
+              >
+                <span className="menuCheck">{isChecked(entry) ? '✓' : ''}</span>
+                <span className="menuLabel">{entry.label}</span>
+                <span className="menuShortcut">{entry.shortcut ?? ''}</span>
+              </div>
+            ),
+          )}
+        </div>
+      )}
+    </span>
+  )
+
+  return (
+    <div className="menuBar" ref={menuBarRef}>
+      {renderMenu('game', 'Game', gameMenuEntries)}
+      {renderMenu('help', 'Help', helpMenuEntries)}
     </div>
   )
 }

--- a/apps/web/src/components/board/WindowBar.tsx
+++ b/apps/web/src/components/board/WindowBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useFlagStore } from '../../common/store/useFlagStore'
 
 // Entries for the classic Windows Minesweeper "Game" dropdown. These are
 // visual only — `check` renders a leading ✓, `shortcut` right-aligns a hint,
@@ -17,7 +18,7 @@ const gameMenuEntries: GameMenuEntry[] = [
   { label: 'Expert' },
   { label: 'Custom...' },
   null,
-  { label: 'Marks (?)', check: true },
+  { label: 'Marks (?)' },
   { label: 'Color', check: true },
   null,
   { label: 'Best Times...' },
@@ -38,6 +39,8 @@ type WindowBarProps = {
 export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
   const [gameMenuOpen, setGameMenuOpen] = useState(false)
   const gameMenuRef = useRef<HTMLSpanElement>(null)
+  const marks = useFlagStore((state) => state.marks)
+  const toggleMarks = useFlagStore((state) => state.toggleMarks)
 
   useEffect(() => {
     if (!gameMenuOpen) return
@@ -52,11 +55,18 @@ export const WindowBar = ({ onSelect, activeDifficulty }: WindowBarProps) => {
 
   const handleSelect = (label: string) => {
     setGameMenuOpen(false)
+    if (label === 'Marks (?)') {
+      toggleMarks()
+      return
+    }
     onSelect?.(label)
   }
 
-  const isChecked = (entry: { label: string; check?: boolean }) =>
-    difficultyLabels.includes(entry.label) ? entry.label === activeDifficulty : !!entry.check
+  const isChecked = (entry: { label: string; check?: boolean }) => {
+    if (entry.label === 'Marks (?)') return marks
+    if (difficultyLabels.includes(entry.label)) return entry.label === activeDifficulty
+    return !!entry.check
+  }
 
   return (
     <div className="menuBar">

--- a/apps/web/src/components/board/minesweeper.css
+++ b/apps/web/src/components/board/minesweeper.css
@@ -1,10 +1,7 @@
 .minesweeper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  position: relative;
+  display: inline-block;
   margin: 4px;
-  border: 4px outset #fff;
-  background-color: #ddd;
 
   .board {
     display: flex;
@@ -12,56 +9,9 @@
     flex-direction: column;
   }
 
-  .windowBar {
-    flex-direction: column;
-    width: 100%;
-    display: flex;
-    flex-grow: 1;
-  }
-
-  .titleBar {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 3px 4px;
-    background: linear-gradient(90deg, #0a246a, #3a6ea5, #6a8ccb);
-    color: #fff;
-    font-family: 'W95FA', 'pixel-art', sans-serif;
-    font-size: 16px;
-    -webkit-font-smoothing: none;
-    margin: 2px;
-  }
-
-  .titleBar .icon {
-    width: 16px;
-    height: 16px;
-    margin: 0 4px;
-  }
-
-  .titleBar .title {
-    flex: 1;
-    text-align: left;
-  }
-
-  .windowButtons {
-    display: flex;
-    gap: 2px;
-  }
-
-  .windowButton {
-    width: 18px;
-    height: 18px;
-    border: 2px outset #fff;
-    background-color: #ddd;
-    color: #000;
-    font-size: 11px;
-    font-weight: bold;
-    text-align: center;
-    font-family: 'pixel-art', sans-serif;
-  }
-
   .menuBar {
     display: flex;
+    align-self: stretch;
     gap: 4px;
     padding: 2px 4px;
     background-color: #ddd;
@@ -72,8 +22,67 @@
     text-align: left;
   }
 
+  .menuItemWrapper {
+    position: relative;
+    margin: 0 4px;
+  }
+
   .menuItem {
+    display: inline-block;
     padding: 1px 6px;
+    border: 2px solid transparent;
+    cursor: default;
+  }
+
+  .menuItem:hover,
+  .menuItem.active {
+    border: 2px outset #fff;
+  }
+
+  .menuDropdown {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 10;
+    min-width: 150px;
+    padding: 2px;
+    border: 2px outset #fff;
+    background-color: #ddd;
+    color: #000;
+    font-family: 'W95FA', 'pixel-art', sans-serif;
+    font-size: 16px;
+    -webkit-font-smoothing: none;
+  }
+
+  .menuDropdownItem {
+    display: grid;
+    grid-template-columns: 18px 1fr auto;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 8px 2px 2px;
+    white-space: nowrap;
+  }
+
+  .menuDropdownItem:hover {
+    background-color: #0a246a;
+    color: #fff;
+  }
+
+  .menuCheck {
+    text-align: center;
+  }
+
+  .menuShortcut {
+    text-align: right;
+  }
+
+  .menuSeparator {
+    height: 0;
+    margin: 3px 2px;
+    border-top: 1px solid #888;
+    border-bottom: 1px solid #fff;
   }
 
   .board .header {
@@ -176,4 +185,63 @@
   .cell-8 {
     color: #6f6f6f;
   }
+}
+
+/* Place the Custom Field dialog floating over the main window, overhanging
+   its right edge like the classic dialog. */
+.minesweeper .window.dialog {
+  position: absolute;
+  top: 56px;
+  left: 22px;
+  min-width: 280px;
+  font-family: 'W95FA', 'pixel-art', sans-serif;
+  font-size: 16px;
+  -webkit-font-smoothing: none;
+}
+
+.customFieldBody {
+  display: flex;
+  gap: 16px;
+  padding: 12px;
+  color: #000;
+}
+
+.customFieldFields {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.customFieldRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.customFieldRow input {
+  width: 48px;
+  padding: 2px 4px;
+  border: 2px inset #fff;
+  background-color: #fff;
+  color: #000;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.customFieldButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Scoped past `.window .windowButton` so the dialog buttons size correctly. */
+.window.dialog .dialogButton {
+  width: 76px;
+  height: 26px;
+  font-family: 'W95FA', 'pixel-art', sans-serif;
+  font-size: 16px;
+  font-weight: normal;
+  cursor: default;
 }

--- a/apps/web/src/components/board/minesweeper.css
+++ b/apps/web/src/components/board/minesweeper.css
@@ -1,4 +1,32 @@
 .minesweeper {
+  /* --- Color theme (the original palette) --- */
+  --body: #ddd;
+  --cell: #ddd;
+  --bevel: #fff;
+  --text: #000;
+  --title-a: #0a246a;
+  --title-b: #3a6ea5;
+  --title-c: #6a8ccb;
+  --title-text: #fff;
+  --menu-hl-bg: #0a246a;
+  --menu-hl-text: #fff;
+  --sep-dark: #888;
+  --sep-light: #fff;
+  --revealed: #ccc;
+  --revealed-border: #bbb;
+  --explode: #c00;
+  --led-on: #c00;
+  --led-off: #600000;
+  --led-def: #1e262e;
+  --n1: #2f0cdb;
+  --n2: #47731b;
+  --n3: #c71d0a;
+  --n4: #19046c;
+  --n5: #5e0a05;
+  --n6: #487f7f;
+  --n7: #000000;
+  --n8: #6f6f6f;
+
   position: relative;
   display: inline-block;
   margin: 4px;
@@ -18,8 +46,8 @@
     align-self: stretch;
     gap: 4px;
     padding: 2px 4px;
-    background-color: #ddd;
-    color: #000;
+    background-color: var(--body);
+    color: var(--text);
     font-family: 'W95FA', 'pixel-art', sans-serif;
     font-size: 16px;
     -webkit-font-smoothing: none;
@@ -40,7 +68,7 @@
 
   .menuItem:hover,
   .menuItem.active {
-    border: 2px outset #fff;
+    border: 2px outset var(--bevel);
   }
 
   .menuDropdown {
@@ -52,9 +80,9 @@
     z-index: 10;
     min-width: 150px;
     padding: 2px;
-    border: 2px outset #fff;
-    background-color: #ddd;
-    color: #000;
+    border: 2px outset var(--bevel);
+    background-color: var(--body);
+    color: var(--text);
     font-family: 'W95FA', 'pixel-art', sans-serif;
     font-size: 16px;
     -webkit-font-smoothing: none;
@@ -70,8 +98,8 @@
   }
 
   .menuDropdownItem:hover {
-    background-color: #0a246a;
-    color: #fff;
+    background-color: var(--menu-hl-bg);
+    color: var(--menu-hl-text);
   }
 
   .menuCheck {
@@ -85,13 +113,13 @@
   .menuSeparator {
     height: 0;
     margin: 3px 2px;
-    border-top: 1px solid #888;
-    border-bottom: 1px solid #fff;
+    border-top: 1px solid var(--sep-dark);
+    border-bottom: 1px solid var(--sep-light);
   }
 
   .board .header {
-    border: 4px inset #fff;
-    background-color: #ddd;
+    border: 4px inset var(--bevel);
+    background-color: var(--body);
     margin-bottom: 8px;
     padding: 4px;
     display: flex;
@@ -107,7 +135,7 @@
     height: 42px;
     align-items: center;
     justify-content: center;
-    border: 4px outset #fff;
+    border: 4px outset var(--bevel);
     padding: 4px;
   }
 
@@ -125,7 +153,7 @@
 
   .field {
     display: flex;
-    border: 4px inset #fff;
+    border: 4px inset var(--bevel);
     padding: 0;
     flex-direction: column;
     align-items: center;
@@ -141,8 +169,8 @@
     height: 28px;
     font-size: 18px;
     line-height: 30px;
-    border: 4px outset #fff;
-    background-color: #ddd;
+    border: 4px outset var(--bevel);
+    background-color: var(--cell);
     align-items: center;
     justify-content: center;
     font-weight: bold;
@@ -153,8 +181,8 @@
 
   .field .cell.revealed {
     transition: 250ms;
-    background-color: #ccc;
-    border: 2px solid #bbb;
+    background-color: var(--revealed);
+    border: 2px solid var(--revealed-border);
   }
 
   .field .cell img {
@@ -166,34 +194,67 @@
 
   /* Only the mine that was clicked to lose the game — not the ones shown at game over. */
   .field .cell.exploded {
-    background-color: #c00;
+    background-color: var(--explode);
   }
 
   .cell-1 {
-    color: #2f0cdb;
+    color: var(--n1);
   }
   .cell-2 {
-    color: #47731b;
+    color: var(--n2);
   }
   .cell-3 {
-    color: #c71d0a;
+    color: var(--n3);
   }
   .cell-4 {
-    color: #19046c;
+    color: var(--n4);
   }
   .cell-5 {
-    color: #5e0a05;
+    color: var(--n5);
   }
   .cell-6 {
-    color: #487f7f;
+    color: var(--n6);
   }
   .cell-7,
   .cell--1 {
-    color: #000000;
+    color: var(--n7);
   }
   .cell-8 {
-    color: #6f6f6f;
+    color: var(--n8);
   }
+}
+
+/* --- Monochrome theme (Color off) — sampled to match the reference screenshot --- */
+.minesweeper.grayscale {
+  --body: #d0ccc0;
+  --cell: #b8bcb8;
+  --bevel: #f8fcf8;
+  --title-a: #204880;
+  --title-b: #6894c0;
+  --title-c: #a0c8e8;
+  --menu-hl-bg: #383c38;
+  --revealed: #b8bcb8;
+  --revealed-border: #909090;
+  --explode: #808080;
+  --led-on: #f8fcf8;
+  --led-off: #383838;
+  --n1: #000;
+  --n2: #000;
+  --n3: #000;
+  --n4: #000;
+  --n5: #000;
+  --n6: #000;
+  --n7: #000;
+  --n8: #000;
+}
+
+/* Image assets (window icon, smiley face, flags/mines/marks) bake in their own
+   colors, so CSS variables can't reach them — desaturate them for the mono
+   theme to match the reference. */
+.minesweeper.grayscale .titleBar .icon,
+.minesweeper.grayscale .observerFace img,
+.minesweeper.grayscale .field .cell img {
+  filter: grayscale(1);
 }
 
 /* Place the Custom Field dialog floating over the main window, overhanging
@@ -212,7 +273,7 @@
   display: flex;
   gap: 16px;
   padding: 12px;
-  color: #000;
+  color: var(--text);
 }
 
 .customFieldFields {
@@ -232,7 +293,7 @@
 .customFieldRow input {
   width: 48px;
   padding: 2px 4px;
-  border: 2px inset #fff;
+  border: 2px inset var(--bevel);
   background-color: #fff;
   color: #000;
   font-family: inherit;

--- a/apps/web/src/components/board/minesweeper.css
+++ b/apps/web/src/components/board/minesweeper.css
@@ -111,6 +111,11 @@
     padding: 4px;
   }
 
+  /* Sink the border in while the reset face is pressed, like a classic button. */
+  .observerFace:active {
+    border-style: inset;
+  }
+
   .observerFace img {
     width: 100%;
     height: 100%;

--- a/apps/web/src/components/board/minesweeper.css
+++ b/apps/web/src/components/board/minesweeper.css
@@ -2,6 +2,10 @@
   position: relative;
   display: inline-block;
   margin: 4px;
+  /* Stop long-press on mobile from selecting cell text or opening the callout. */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
 
   .board {
     display: flex;
@@ -228,6 +232,8 @@
   color: #000;
   font-family: inherit;
   font-size: inherit;
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 .customFieldButtons {

--- a/apps/web/src/components/board/minesweeper.css
+++ b/apps/web/src/components/board/minesweeper.css
@@ -1,3 +1,14 @@
+@keyframes menuSlideDown {
+  from {
+    opacity: 0;
+    transform: scaleY(0.4);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
 .minesweeper {
   /* --- Color theme (the original palette) --- */
   --body: #ddd;
@@ -71,6 +82,11 @@
     border: 2px outset var(--bevel);
   }
 
+  /* Underline the keyboard accelerator letter (G in Game, H in Help). */
+  .menuItem::first-letter {
+    text-decoration: underline;
+  }
+
   .menuDropdown {
     display: flex;
     flex-direction: column;
@@ -86,6 +102,8 @@
     font-family: 'W95FA', 'pixel-art', sans-serif;
     font-size: 16px;
     -webkit-font-smoothing: none;
+    transform-origin: top;
+    animation: menuSlideDown 120ms ease-out;
   }
 
   .menuDropdownItem {
@@ -306,6 +324,23 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.helpBody {
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  max-width: 260px;
+  color: var(--text);
+}
+
+.helpBody ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.helpButtons {
+  justify-content: flex-end;
 }
 
 /* Scoped past `.window .windowButton` so the dialog buttons size correctly. */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5,7 +5,7 @@
 
   color-scheme: light dark;
   color: #000;
-  background-color: #242424;
+  background-color: #3a6ea5;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -58,7 +58,7 @@ button {
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
-    background-color: #ffffff;
+    background-color: #306ca0;
   }
   a:hover {
     color: #747bff;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,7 +4,7 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
+  color: #000;
   background-color: #242424;
 
   font-synthesis: none;
@@ -39,22 +39,20 @@ h1 {
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
   transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  border-radius: 0;
+  justify-content: center;
+  padding: 2px 8px;
+  line-height: 0;
+  align-items: center;
+  cursor: pointer;
+  border: 2px outset #fff;
+  background-color: #ddd;
+  color: #000;
+  font-size: 11px;
+  font-weight: bold;
+  text-align: center;
+  font-family: 'pixel-art', sans-serif;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## Summary

Builds out the classic Windows Minesweeper experience on top of a new reusable `Window` chrome component. (Recreated against `main`; supersedes the closed #18 which targeted `master`.)

- **Custom Field & difficulties** — a Custom Field dialog plus Beginner / Intermediate / Expert presets wired to the board; Custom inputs are clamped (height ≤ 30, width ≤ 24, mines between 10 and width×height−1).
- **Window chrome** — reusable `Window` (frame + title bar) extracted to `common/components`; SVG minimize/maximize/close buttons, a pixel-exact classic raised frame on a blue desktop, a disabled/greyed maximize, and **windows draggable by the title bar**, clamped so they can't leave the viewport.
- **Menus & keyboard** — `Game` and `Help` dropdowns (mutually exclusive, slide-down animation, underlined G/H accelerators). Keyboard: `G`/`H` open the menus, `F2` starts a new game (like the reset face). `Help` opens **Help Topics** and **About Minesweeper** dialog windows.
- **Themes & toggles** — all colors extracted to CSS variables driving a **color** theme and a **monochrome** theme; the `Color` menu item swaps them. `Marks (?)` toggles whether the flag cycle includes the question mark.
- **Faces** — a surprised face while a cell is pressed (until the move resolves); the reset face presses in on click.
- **Mobile** — long-press flags cleanly (no text selection / callout).
- **SEO** — real page `<title>`, description, Open Graph / Twitter / canonical tags, and a rewritten README.

## Testing

- `pnpm lint` (max-warnings 0), `pnpm test` (80 tests), and `pnpm build` all pass.
- Each change was verified interactively in a browser (menus, dialogs, drag/clamp, theme swap, faces).
